### PR TITLE
initial commit for docker-stats

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,25 @@
+image: bradrydzewski/base
+notify:
+  email:
+    recipients:
+    - drone@clever.com
+  slack:
+    on_failure: true
+    on_started: false
+    on_success: false
+    webhook_url: $$slack_webhook
+publish:
+  catapult:
+    url: $$catapult_url
+    application: "docker-stats"
+  docker:
+    docker_host: $$docker_server
+    email: $$docker_email
+    image_name: clever/docker-stats
+    password: $$docker_password
+    registry_login: true
+    tags:
+    - $(git rev-parse --short HEAD)
+    username: $$docker_username
+    when:
+      branch: master

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,60 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# def dockerfile
+Dockerfile.dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:2.7
+ENTRYPOINT ["/usr/bin/start.sh"]
+
+COPY ./diamond.conf.template /usr/bin/diamond.conf.template
+COPY ./start.sh /usr/bin/start.sh
+RUN pip install git+git://github.com/Clever/Diamond.git@a11370fde554056e022afbdb4298587f20e9ee20 \
+    && pip install boto \
+    && pip install influxdb==v2.9.1 \
+    && pip install docker-py==1.6

--- a/diamond.conf.template
+++ b/diamond.conf.template
@@ -1,0 +1,136 @@
+################################################################################
+# Diamond Configuration File
+################################################################################
+
+################################################################################
+### Options for the server
+[server]
+
+# Handlers for published metrics.
+handlers = diamond.handler.influxdbHandler.InfluxdbHandler
+
+# User diamond will run as
+# Leave empty to use the current user
+user =
+
+# Group diamond will run as
+# Leave empty to use the current group
+group =
+
+# Pid file
+pid_file = /var/run/diamond.pid
+
+# Directory to load collector modules from
+collectors_path = /usr/local/share/diamond/collectors/
+
+# Directory to load collector configs from
+collectors_config_path = /etc/diamond/collectors/
+
+# Directory to load handler configs from
+handlers_config_path = /etc/diamond/handlers/
+
+# Interval to reload collectors
+collectors_reload_interval = 3600
+
+################################################################################
+### Options for handlers
+[handlers]
+
+# daemon logging handler(s)
+keys = stdout
+
+### Defaults options for all Handlers
+[[default]]
+
+[[InfluxdbHandler]]
+hostname = <INFLUXDB_HOST>
+port = <INFLUXDB_PORT>
+ssl = True
+username = <INFLUXDB_USER>
+password = <INFLUXDB_PASS>
+database = <INFLUXDB_DB>
+batch_size = 50
+cache_size = 20000
+
+################################################################################
+### Options for collectors
+[collectors]
+
+[[default]]
+### Defaults options for all Collectors
+
+# Uncomment and set to hardcode a hostname for the collector path
+# Keep in mind, periods are seperators in graphite
+# hostname = my_custom_hostname
+
+# If you prefer to just use a different way of calculating the hostname
+# Uncomment and set this to one of these values:
+
+# smart             = Default. Tries fqdn_short. If that's localhost, uses hostname_short
+
+# fqdn_short        = Default. Similar to hostname -s
+# fqdn              = hostname output
+# fqdn_rev          = hostname in reverse (com.example.www)
+
+# uname_short       = Similar to uname -n, but only the first part
+# uname_rev         = uname -r in reverse (com.example.www)
+
+# hostname_short    = `hostname -s`
+# hostname          = `hostname`
+# hostname_rev      = `hostname` in reverse (com.example.www)
+
+# hostname_method = smart
+
+hostname = docker-stats
+
+# Path Prefix and Suffix
+# you can use one or both to craft the path where you want to put metrics
+# such as: %(path_prefix)s.$(hostname)s.$(path_suffix)s.$(metric)s
+path_prefix =
+# path_suffix =
+
+# Path Prefix for Virtual Machines
+# If the host supports virtual machines, collectors may report per
+# VM metrics. Following OpenStack nomenclature, the prefix for
+# reporting per VM metrics is "instances", and metric foo for VM
+# bar will be reported as: instances.bar.foo...
+# instance_prefix = instances
+
+# Default Poll Interval (seconds)
+interval = 60
+enabled = False
+
+[[DockerStatsCollector]]
+enabled = True
+name_from_env = MARATHON_APP_ID
+
+################################################################################
+### Options for logging
+# for more information on file format syntax:
+# http://docs.python.org/library/logging.config.html#configuration-file-format
+
+
+[loggers]
+keys = root
+
+# handlers are higher in this config file, in:
+# [handlers]
+# keys = ...
+
+[formatters]
+keys = stdout
+
+[logger_root]
+# to increase verbosity, set DEBUG
+level = INFO
+handlers = stdout
+
+[handler_stdout]
+class = StreamHandler
+level = INFO
+formatter = stdout
+args = (sys.stdout,)
+
+[formatter_stdout]
+format = %(asctime)-15s diamond[%(process)d] %(message)s
+datefmt = %b %d %H:%M:%S

--- a/launch/docker-stats.yml
+++ b/launch/docker-stats.yml
@@ -1,0 +1,11 @@
+run:
+  type: docker
+env:
+  - INFLUXDB_USER
+  - INFLUXDB_PASS
+  - INFLUXDB_DB
+  - INFLUXDB_HOST
+  - INFLUXDB_PORT
+resources:
+  cpu: .1
+  max_mem: .1

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+mkdir -p /etc/diamond
+sed -e "s/<INFLUXDB_USER>/$INFLUXDB_USER/" \
+    -e "s/<INFLUXDB_PASS>/$INFLUXDB_PASS/" \
+    -e "s/<INFLUXDB_DB>/$INFLUXDB_DB/" \
+    -e "s/<INFLUXDB_HOST>/$INFLUXDB_HOST/" \
+    -e "s/<INFLUXDB_PORT>/$INFLUXDB_PORT/" \
+    /usr/bin/diamond.conf.template \
+    > /etc/diamond/diamond.conf
+exec diamond -f --skip-change-user --skip-fork


### PR DESCRIPTION
This container starts diamond with only a docker stats collector and an influxdb handler.  This will not actually be able to be deployed as a normal mesos app because it requires mounted volumes, so we will deploy it like other system containers using `mesos.apps.native`.
