### PR TITLE
Removed unneeded "Install awscli for ECR publish" command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,13 +17,5 @@ jobs:
         command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
         name: Set up CircleCI artifacts directories
     - run: echo "no tests"
-    - run:
-        command: |-
-          cd /tmp/ && wget https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
-          sudo apt-get update
-          sudo apt-get install python-dev
-          sudo pip install --upgrade awscli && aws --version
-          pip install --upgrade --user awscli
-        name: Install awscli for ECR publish
     - run: $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
     - run: $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS docker-stats


### PR DESCRIPTION
## This an automated PR
*Risk rating*: low :cat:

Individual circle-ci commands now install the awscli automatically.

Also removed deprecated report-card commands.

Context:
- https://clever.atlassian.net/browse/INFRA-3343
